### PR TITLE
Allow React 17 peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,8 +97,8 @@
     "webpack": "^4.44.1"
   },
   "peerDependencies": {
-    "react": ">= 16.8",
-    "react-dom": ">= 16.8",
+    "react": ">= 16.8 || ^17.0.0",
+    "react-dom": ">= 16.8 || ^17.0.0",
     "react-window": ">= 1.8.5"
   },
   "dependencies": {


### PR DESCRIPTION
Cannot easily include in NextJS v11 projects otherwise.